### PR TITLE
Fixed MSVC specific pure virt function specifier

### DIFF
--- a/include/GraphicalEngine.hpp
+++ b/include/GraphicalEngine.hpp
@@ -21,7 +21,7 @@ class GraphicalEngine
 public:
 	GraphicalEngine();	
 
-	virtual void renderFrame(std::shared_ptr<Scene>) = 0{};
+	virtual void renderFrame(std::shared_ptr<Scene>) = 0;
 
 	void bindScene(std::shared_ptr<Scene> scene);
 	void unbindScene(std::shared_ptr<Scene> scene);


### PR DESCRIPTION
Removed the brackets on the pure virtual function specifier allowing us to build in non-MSVC kits