### PR TITLE
Vertex normals are now also multiplied by model matrix

### DIFF
--- a/res/shaders/Basic/Basic.vert
+++ b/res/shaders/Basic/Basic.vert
@@ -47,7 +47,7 @@ out LightSpaceVertexOutput{
 void main()
 {
 	VertexOut.objectColor = aObjectColor;
-	VertexOut.Normal = aNormal;
+	VertexOut.Normal = mat3(instanceMatrix) * aNormal;
 	VertexOut.TexCoords = aTexCoords;
 	VertexOut.FragPos = vec3(instanceMatrix * vec4(aPosition, 1.0f));
 


### PR DESCRIPTION
Despite the fact that we offered model rotation, we did not account for the normals

The result was that when models were rotated in-engine, illuminations of the surface of the models would come out wrongly because the normals of the faces would not be rotated accordingly

I added a multiplication between the imported normal values and a 3x3 matrix built from the rotation constituents of the model matrix