### PR TITLE
Window icon path fix

### DIFF
--- a/src/rendering/openGLContext.hpp
+++ b/src/rendering/openGLContext.hpp
@@ -94,7 +94,7 @@ GLFWwindow *InitializeOpenGLContext()
 
     // Window Icon
     GLFWimage images[1]; 
-    std::string iconPath = ROOT_DIR + std::string("/res/icon.png");
+    std::string iconPath = PROJECT_ROOT_DIR + std::string("/res/icon.png");
     images[0].pixels = stbi_load(iconPath.c_str(), &images[0].width, &images[0].height, 0, 4); //rgba channels 
     glfwSetWindowIcon(window, 1, images); 
     stbi_image_free(images[0].pixels);


### PR DESCRIPTION
The old icon path was sourced from a relative path that would change whenever the project was imported by a consumer CMake project.

Changed it into a permanent path always inside FluxLumina's folder structure